### PR TITLE
I've added `clasp-list.json` generation to the workflow.

### DIFF
--- a/.github/workflows/update-clasp-list.yml
+++ b/.github/workflows/update-clasp-list.yml
@@ -40,6 +40,14 @@ jobs:
           echo '--- First 5 lines of clasp-list.txt ---'
           head -n 5 clasp-list.txt
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x' # Specify Python version
+
+      - name: Generate clasp-list.json
+        run: python parse_clasp_list.py
+
       - name: Check if clasp-list.txt changed
         id: check-changed
         run: |
@@ -51,12 +59,12 @@ jobs:
             echo "changed=false"
           fi
 
-      - name: Commit and push clasp-list.txt to gas-pull branch
+      - name: Commit and push changes to gas-pull branch
         if: steps.check-changed.outputs.changed == 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add clasp-list.txt
-          git commit -m "Update Apps Script projects list"
+          git add clasp-list.txt clasp-list.json
+          git commit -m "Update Apps Script projects list and JSON"
           # gas-pull ブランチに強制プッシュ
           git push origin gas-pull --force

--- a/clasp-list.json
+++ b/clasp-list.json
@@ -1,0 +1,430 @@
+[
+    {
+        "name": "Bookmark Spreadsheet",
+        "id": "1gb8NXL4DwVwkdnSDBjgu1bjH55PgaaQXX_vm5sLJqjIbdBRI4C-ROQqs"
+    },
+    {
+        "name": "Calendar Log",
+        "id": "1DzGVrsZvn5Svk_I7f48AiSeYrzDP0wIWsCxkHrS6B5ZFThcamXB0wwo0"
+    },
+    {
+        "name": "File Triage",
+        "id": "1DJbk8E57h7UVVXyzS9PIDn_iL0ZJf39VRdLepQbf_DDI9WPVkzVlSN2Z"
+    },
+    {
+        "name": "dns.moukaeritai.work",
+        "id": "1ncv2vCJ4Yoz_ZF1dATET1NlEI0HAeCalrq3yqhnUuSZ9leOxYhq9nK4M"
+    },
+    {
+        "name": "Moodle multichoice…",
+        "id": "1z3HCVNHvj2W-flbvkl2y-5QCWnl_GF4cPDqMbA2IlvbXqhtneLvEDEBz"
+    },
+    {
+        "name": "Show Google Tasks",
+        "id": "1-wPE2i22f0Awr1fkg9z0XDxIQeLPlvSOOQ7kzYCSQd1YPNkFo5MwkLiJ"
+    },
+    {
+        "name": "Document Saver",
+        "id": "11rpH01pllhsLXw8piWIWlI06yc_BrfqQ4sAP9jxRMgbq1mXrg3mHVmzQ"
+    },
+    {
+        "name": "Moodle true/false…",
+        "id": "1yeQ42lIGOQq2Zkl33L0B6RdUfdtH-e_8rqEaHLoRXCu3iwHrc7EjDixf"
+    },
+    {
+        "name": "ImeDictionary Aggre…",
+        "id": "1bv9vqLAy7LQO1ek_nOrb7iSrcQO8pcGr_NhiP75qJ3fjggqvkiZ6FAqN"
+    },
+    {
+        "name": "ImeDictionary Libra…",
+        "id": "1OcQHj6g4a4jpoBpIKeacLAv1j9t-I6vGn2t91zyRqL3MHZC8inEUcpSb"
+    },
+    {
+        "name": "Markdown2GoogleDocs",
+        "id": "1Uf0YpVntqswRo0bwSXCBA7glomAfrNz43dxiJziapYeXIy90b_EHpt3_"
+    },
+    {
+        "name": "DriveMetaViewer",
+        "id": "18fkObcqcU91kBSTc0UHqI3vOyd1zxSX6CHvJxaE1Urn6T-dS9d_lLiKj"
+    },
+    {
+        "name": "DocImageResizer",
+        "id": "1fWFGiC7PwwYBmNTY12zxbSdBqkgP6RKta-bGSFDD90jliFIYOqxHbYEg"
+    },
+    {
+        "name": "Published Form Pars…",
+        "id": "1rscecWbcSJ3xD5z7QmT0ZJde73TQWOwQaA7jrxTVNgpOxd-7DYeLtI3V"
+    },
+    {
+        "name": "Layout Library",
+        "id": "1cQ2Y30dXVHjU6JVuod9G_aOXGo-9CRAkIej7-lG8YCVPQUcJrKg9kVvj"
+    },
+    {
+        "name": "Javascript Proxy",
+        "id": "1q1-0M4PCEaMBcsPQ13HVp6S_j4gP7rbmXjp_8R8uribE2PPVp7lZTg-8"
+    },
+    {
+        "name": "Markdown in Sheet…",
+        "id": "155SE7dCPH52t6l_we4avFQGhawNVjChOTiMdRC8UYuniDb_UWwW-yIx8"
+    },
+    {
+        "name": "物件選択アンケート",
+        "id": "1VGrvbuilEvfwcJXQ2mx9VmO6doyD7RlpT9-1n3oThjIBYz1kMUBOl-Jr"
+    },
+    {
+        "name": "Google Apps Script…",
+        "id": "17SmjkOHGM7bAnLPoePgH-hC45i6YCAgORgTA66hdmqqnMm2p7_goR8C1"
+    },
+    {
+        "name": "Google Cloud Vision…",
+        "id": "1_SuiFIOR_EKToX4e2h8Jp3IEi8iSlJBnH24i2zQZSq2ETXDRTHXsQps3"
+    },
+    {
+        "name": "CsvParser",
+        "id": "1lNnrAhYlTFhmxDlSI-HRypOATxNcsujO3hpUMK5MJTl-Ozt_CjRFE08c"
+    },
+    {
+        "name": "(obsoleted) Html…",
+        "id": "1XB8G6BUwfRJsR9KyHOaEX8F1D2k3hmP0tB5Zec6cKoXNwx4hA4turlAj"
+    },
+    {
+        "name": "Google日本語入力ユ…",
+        "id": "1AavEYmp44tHxyqTvV8kBTHM26zOaUdsVDjr6KMnKojbV5kPwr2EJ6LLi"
+    },
+    {
+        "name": "MyProgressStrip",
+        "id": "1q8vDJ1xEbrkOYBgSuxyqjQ8r_W12OgUqhN-SzxhzTLJvLfB6X93MC_kg"
+    },
+    {
+        "name": "GAS Library Viewer",
+        "id": "1YAxockQcSTXfpD08yNET6PkcuJP2VGWlikGNineVeMx68CC-x4E07rax"
+    },
+    {
+        "name": "Html",
+        "id": "1jiI5HqUgUVyI4LA4gFueiux_mHjFuKlgJIVYY4EjRwIx0MAWqi5-Eyef"
+    },
+    {
+        "name": "Spreadsheet Utility…",
+        "id": "1HdefH6zukEzlrAQNol72ckv9GbjCirkQM4RqrJbnjktxuW9n7k5ysfR8"
+    },
+    {
+        "name": "Hash Wrapper",
+        "id": "1NYN_AoEoGoZIOKurCE2dSWFMzpBTeZFczQ-q_F4d-mvQ2XK6rdtz3Zev"
+    },
+    {
+        "name": "GetFragmentPartOfUr…",
+        "id": "1A_kkWBH9eqn08Rir8tv_KdaVyYZkJt487UD69qAbQ0fGHCjKKTPwhC0H"
+    },
+    {
+        "name": "Spreadsheet Addon（…",
+        "id": "1LSYokZ_LmtIkXv-URsN99givIHlIkDNHwQjkLAo6JkzwLvsbagpdbTaE"
+    },
+    {
+        "name": "Hash",
+        "id": "1nH20n09gtpxjWEo5FUv9Ixor2nIO0Et0GJ8emW6dIOsgYQf7LXBUwNG0"
+    },
+    {
+        "name": "Spreadsheet Helper",
+        "id": "1gZ1kwgVe2ZTz6B5c2N-OtdasCjRnuoeitNyuQmuESKYTrpryZk4GEMxG"
+    },
+    {
+        "name": "HelloJwt",
+        "id": "1RsAjkBTBEy4w8Q0kdStuJAXbAIcrnVqXvMGDj5nhQJkmZuMT3tBFTFoE"
+    },
+    {
+        "name": "JsDoc",
+        "id": "1WC3AZoysl3LOVPj2WtyX-wBn6Ecvyv6fUjulDRUVhoNI_fN40d3KaCGV"
+    },
+    {
+        "name": "Automate flows",
+        "id": "1M1amG2VwddxG9UpHjERfroY9wntSro8xSbEE02tVJnvsg7pQ_AsNS6p5"
+    },
+    {
+        "name": "Kakaku Library",
+        "id": "1L9H8eQdinme63XIk8TtgfH5u-zn0KVqw4UnwWUj6yhW3SMJlXJkq7AKm"
+    },
+    {
+        "name": "send-to-kindle",
+        "id": "1a5RnEduBLbD4kq4NHlyiGZChdRTXyxT6rnUs-JB7-_f2tM4fV1SONhd5"
+    },
+    {
+        "name": "GasOAuthLibrary",
+        "id": "191-QOfGkDNe9otT_2cJxL1Afh04ulD8ArB5JnPkM7yddJ2-OiUTvvtVJ"
+    },
+    {
+        "name": "Snippets For DriveA…",
+        "id": "1KmIn9qigeR161F2AoSp2Dltb5InjiUJ1AgmmOlyqYN1441K2ku8WNiiU"
+    },
+    {
+        "name": "松山市プレミアム商…",
+        "id": "1lhUG7nF6LqCfFV2ZzITuEuIPolWJ6vt9HYdGGoQnicxm-EgyGu198-0g"
+    },
+    {
+        "name": "ArecXのスター表示に…",
+        "id": "1iSAbJgupNLOxKwff9-bHeJ1whiE8sZmCxy2eb5D7qDyl4nZE_LjrKpHA"
+    },
+    {
+        "name": "FileChooser",
+        "id": "1kmWE6C2RkVxw1nAymD1HXkgAjENsCCNajiuKwwQjF81fGjwb7shhMKk4"
+    },
+    {
+        "name": "SheetHelper",
+        "id": "1yHbFwsxR7LGHpT-AaYcepbv3DObqkvGp1JfqLiL4SmYYgRHRrWf50kxt"
+    },
+    {
+        "name": "Download Items from…",
+        "id": "1p7R-6QdWJBVNQHYeLgL-0shyTRhOuZ_nrMVYLqX3M6rdv6Ot2nABez0n"
+    },
+    {
+        "name": "Twitter Unblock and…",
+        "id": "1iFYcSphfVXjCkBAZ8aGqIU5L37rvFjqLdLP0YsuLPWoOPm_xj0YRJ4uL"
+    },
+    {
+        "name": "Untitled project",
+        "id": "1FSAJj929as1EcS03jp-NAAueuy_VTWtzNfiL7EoiG9uFBf0o7wVBaQHQ"
+    },
+    {
+        "name": "Google Driveの一覧…",
+        "id": "13faGzNt1a3JjMs8zCfYdm9-L7UCtrWa16Ha5G-_Q9-8yxAZxRCylv6eY"
+    },
+    {
+        "name": "UUID generator",
+        "id": "1EGXorZ5FfN-bpWU5PpYdqdt3hSbt84hWhsk7tMXN9J2L2w3HUHBBXWZc"
+    },
+    {
+        "name": "Base32",
+        "id": "1la6BhVxQnF3NhstdhUEJILODy23g3W-7BzKm-p867c7G-jQvCOVCY5Tk"
+    },
+    {
+        "name": "PublicWebCache",
+        "id": "1lUx3c6HCcad3YYZOVb8lO7DzzTGZQWkbRwU_HMY-PHEZrqMu6roXSnKN"
+    },
+    {
+        "name": "Echo",
+        "id": "1qt5XuJT9yqEmtFJoVrEm1HEbplsp1ZSYtJ76IsdSk1CDfwkWqAGz198x"
+    },
+    {
+        "name": "notion-page-title-e…",
+        "id": "1J1eizA18n82rnRB0bWEWXQuyx6ca6FlI4rCQpsMX2K1-_RSj57HmU-cK"
+    },
+    {
+        "name": "GPT with memopad",
+        "id": "1x2MezlZVu4l6hHwOjLQY8hrdjx4i-ZMg7g7DNLn_Qm_D-j5Bqfkw_v_S"
+    },
+    {
+        "name": "Anonymous Cache",
+        "id": "1Zx_o3LVk8gY7QSBrdWR1BvEYU5v2JDK-JPdEXGS6U-HFdZUUX4n2utOT"
+    },
+    {
+        "name": "Untitled project",
+        "id": "16KG4N2zbYxh_VPQwALvPDukRVC6a-zCt2gAE1-2C0GkxKJdlvoe1G3oN"
+    },
+    {
+        "name": "JustCache",
+        "id": "1ye0LXwZ4NyWjO8jnljnGDXMyNDSsAsFotCeMVcC3dtr0gLVOgGEXVZlg"
+    },
+    {
+        "name": "URL Bookmark parser",
+        "id": "1-DK5w5wmpLrTNKv8-WNrAn9oVJ0vf6Oh7Z29Q2h-0ZMtSkr6yC2U1dsR"
+    },
+    {
+        "name": "ContentService test",
+        "id": "1K5yN1kcV4s3nfkuRpmXWwMX8rMylejrSz63HO8__7M1zUtL-h-cqPxpH"
+    },
+    {
+        "name": "Google Colaboratory…",
+        "id": "1R6Wr7q2KhcEMl6aUGc4YtwcKyuDfPkX-duWxyA93qLVLnpvAFkx47N4r"
+    },
+    {
+        "name": "Public ScriptCache",
+        "id": "107zb2vOE4Cn-ziIbJRk0AavZeS5l_suZIQplfhuzAeCSqaef7jYvxdP_"
+    },
+    {
+        "name": "Copy of Public Scri…",
+        "id": "1-0bJIb3TYc29MosGWLbTUl12TuVC7_W_BccV_moQwZX9HXqR8bnb6wcs"
+    },
+    {
+        "name": "Pocket to Sheets…",
+        "id": "1bx4FYU9Udq0fl6JUI5tWdGQTW-MiZctHSpI3kR5hy-sZtLEOCTK0mXBy"
+    },
+    {
+        "name": "Sticker Voting v1",
+        "id": "1ZoVS-ez7yPdNhbknvqjotEMC3p5xDrmzvTwgIo_mmMd2Y3DhyqVzRYiS"
+    },
+    {
+        "name": "ChatGPI Archives",
+        "id": "1x28p9g4GUQ1Yf-rdWm3b0CIqLrcSHJlI_Adg784nFm0b2x1vvcQSRhTm"
+    },
+    {
+        "name": "感情分析",
+        "id": "1tEJHwlwUnrmb4488tbOkvhlBBfrAVHflvXT2WqXp_z8GGNgIi-Mv5VQ6"
+    },
+    {
+        "name": "WebClipboard",
+        "id": "1glSqRTMOxnhV3fGvaiuoJRMW0EM1bHIDurZbjph6lmp8bZYKOcP5s9WP"
+    },
+    {
+        "name": "StringEx",
+        "id": "1GYfj-JgHwhPdQoxpqfD-wL0XXCJtm972x4fXr291WkLbFEsCp-yhkodK"
+    },
+    {
+        "name": "Gmail Search Sheets",
+        "id": "19gfPoC2um5FcDCPyzHenOg_MUHsJruM9X82VQqeR9zxdZEg0wnbWRwQM"
+    },
+    {
+        "name": "Snippets",
+        "id": "1LuCC_nahtVS-4EMIxLDIEoRRIssXrmNKOH3ggZuEk14jfAMDB6uTUCle"
+    },
+    {
+        "name": "Google Takeout File…",
+        "id": "1z_jBz0uoeT8VfbsuBhbw9op6GBZSolw89bFbEx3J4HDmCTOCfhsfwOoN"
+    },
+    {
+        "name": "Untitled project",
+        "id": "1-oFq3B2G4PgnzCmmXpxiOO8JIUOHXoSO7lnKyUSZB_EJb8rA2OGzypw2"
+    },
+    {
+        "name": "Slack Playground",
+        "id": "1PnI4XHOcM36rGvhn5ox_Eb6bWIMlZvPMK7TX1EP2sX-Qu-dywJLwfizW"
+    },
+    {
+        "name": "Understanding Third…",
+        "id": "1hAcanrB68UTn-SUi_5qMYErKZcnupVtz1YrxM9zzJaoIdKEt0r950dyI"
+    },
+    {
+        "name": "Docs Headings Addon",
+        "id": "1Ck4-5l9YWT52gsWOnLGlVqc-H2dtVOMwUhKCoPKFKZ4qS4Ii_CDgdOfz"
+    },
+    {
+        "name": "Glitch Projects",
+        "id": "1EUaapnjQf2c1QcTtEct0GWeztTGAByDD1jD2n1iFu17m7ycr0Wq0bQyn"
+    },
+    {
+        "name": "Google Keep to Goog…",
+        "id": "13rMvpSI80JS1Hq3MMwLOwGBZmIWHX71VDyq8Gj8o2P3X_YS-jLV313Xs"
+    },
+    {
+        "name": "Form Addon",
+        "id": "16aPNNXwgQT5HUc7ch5nkTC9NfCbvHBFjVRr2KiiKSRXPnV0l1LjhXvdB"
+    },
+    {
+        "name": "String Utility Libr…",
+        "id": "1bgCdh7JZGqTUHEV814A-YLhsj053Z0Zly54QIWusrHK1hsEeYGNqvRol"
+    },
+    {
+        "name": "Table",
+        "id": "145HOZDGMnvmYoPGYsN--JfNWQtotCDYFYLeSh-dPm-VQxx9sVlWE64um"
+    },
+    {
+        "name": "ObjectsSheet",
+        "id": "1Q2CN9ciOLohbeWioR_RSv-OszsVlN2-S1FtzugY0ZoR77sgWiTlCaZbG"
+    },
+    {
+        "name": "Google Cloud Resour…",
+        "id": "1Ukzd26N4sR2e_S_ZmBB2Z_dEIYXzuT8JkZu6DUNnHt53v-PSIG_9HB8k"
+    },
+    {
+        "name": "Snippets For Gmail",
+        "id": "152hdXdkyiKko-Ciggv_GdV8b5TQ83ZrV5E2MB-j8ayW_S5zVxLim7YWL"
+    },
+    {
+        "name": "HOTP",
+        "id": "1d_tEHQAW3ZrD1zcIcdYG2kxKHNTA_IDyrBJEkVNxOTv6e6qLlIUsa1Mn"
+    },
+    {
+        "name": "URI",
+        "id": "1Bxt-4ULv8Rh0aAmltAcAUZpOmp8ifF5d_9f-DzASSJkDEAtSHNwlm1Gh"
+    },
+    {
+        "name": "Snippets For Spread…",
+        "id": "1Y1_JzAgUas7Wi8Wou9aASAMaBNNc19zDuIOJdkKGrt9GZAYltA7EMDeQ"
+    },
+    {
+        "name": "Addon Helper",
+        "id": "1ryBTdV-IJH57QxJefgX334JWuJ7KHLjpT43v45VAqwAmFSKqkXkMFnAY"
+    },
+    {
+        "name": "String Utility",
+        "id": "1toCTzwoHcWb0VQGQ3aYO9QZpRY9P5f4g3Hn4K9FCWFIth7OJjW4jssP5"
+    },
+    {
+        "name": "Outlook Web App Fol…",
+        "id": "1pI3uylENjL9mgMFifDvwraraNgxCnyjVN3Cx76xNH4qqWIxFqC5C_ctU"
+    },
+    {
+        "name": "Web Clipboard Writer",
+        "id": "14OUFXtFBsyL7_H3lGOSzCTPlSegMO3VE2fN6ZuW4t6FDexc6370Fl1CJ"
+    },
+    {
+        "name": "Assert",
+        "id": "10lJqYuurUoouFS-aPsPs4HU2s--Xkm5vTu7QVZH4HwcAZgtCDU6ZltQN"
+    },
+    {
+        "name": "Web Clipboard Reader",
+        "id": "1DODUgAitkJ2cD9jdo-xbYfMbJQIM_LwQioFIWxu8TBYj-d1GJc_JsLYe"
+    },
+    {
+        "name": "Is",
+        "id": "1ovfzNY0BUREXY5Ky0eX1HZaz3VxEoq3wyjwZuYg4L6m8H83Rjb8Q1yhw"
+    },
+    {
+        "name": "Datastore",
+        "id": "1LXZ33F_GXt5lZLQj-0qTirlr2jG-D0nBn6A8SX2RyqD4bBOEZTRT_sz7"
+    },
+    {
+        "name": "Mozilla PDF.js",
+        "id": "1LHcsYXfrTmZAC2WxM-FHRiClhiFacYtIj5OWaZlnVnDHjGXCxWQMNLnw"
+    },
+    {
+        "name": "Random",
+        "id": "1NtKt5zOmO0Hvgx_6Jxfl1xyHSK4A65O9krJSfqUfdx-mfjp1fcqiRbSr"
+    },
+    {
+        "name": "Str",
+        "id": "13sX98YHiFh-5eBWTAJtWR52SbdnCxaHzX3GXgt8zUU07ELz9ArLhlJvD"
+    },
+    {
+        "name": "Sha1",
+        "id": "1oKLfiJY_0SIAx62t0fHFW0dcgkq41VNJZaxhoUqurNP_LKxKh6xTa3WN"
+    },
+    {
+        "name": "GmailThreadTable",
+        "id": "1SN862ojGSUHB0KjJW-p4iYu8O_U8OYBnOsYMIQhb4soKnnioCHCVhH72"
+    },
+    {
+        "name": "JsonTable",
+        "id": "1JsxPkJk_0isXeZwzI5EbpXCgTDvNmp_6NKrrNx61q_iefSjQwe5eEZzC"
+    },
+    {
+        "name": "Gmail Label Manimul…",
+        "id": "1ZKdRjD7_vTfM1WdztdpTZATzOwvO8cWg5sZcDBgfdHAjny_DXH2sK3Zk"
+    },
+    {
+        "name": "Cache Clipboard",
+        "id": "1RvhfmTi5Il33TqPVCX0SzkgOTN14obJxdEDrv69CkfBuKHQ6LXSnIAQ5"
+    },
+    {
+        "name": "Gmail Addon",
+        "id": "1qbZkCgB4yUYFF3G4P2oBtOfCNfV73d0jG-ov4Iea7rXq6yO3lnT2LB_2"
+    },
+    {
+        "name": "kenqweb2 to researc…",
+        "id": "1OFyuUHAA2lLSjmadG07uEnafWEoRj18X5FqpFk2Oi1Z0xtFXCKx7g0es"
+    },
+    {
+        "name": "Github Repository…",
+        "id": "1JVePgIVR2zhTuWZPLChi12dd6qAJSuCcIU68z4YeQoPuzyOYmMPFM0hY"
+    },
+    {
+        "name": "Xor",
+        "id": "1tPNJshkGnHrSKO5HIkFGvTyrCm6nZDQsDAxn-p38VhHI17ovSVpEA_uJ"
+    },
+    {
+        "name": "Script Cache",
+        "id": "1N94EvQQ3JB0od091wek3iOQ5bHxKxDZiHfW1fhsuLLKbPlo7uyVicKxE"
+    },
+    {
+        "name": "Unicode Normalizati…",
+        "id": "1lG3a8hUu7QGk0rJ6RFycFl0p7YoZIHjn9k6SWeXEPryUvW-GKupvITNp"
+    }
+]

--- a/parse_clasp_list.py
+++ b/parse_clasp_list.py
@@ -1,0 +1,59 @@
+import json
+import re
+
+def parse_clasp_list(input_filepath="clasp-list.txt", output_filepath="clasp-list.json"):
+    """
+    Parses a list of Google Apps Script projects from a text file and outputs a JSON file.
+
+    Args:
+        input_filepath (str): Path to the input text file (default: "clasp-list.txt").
+        output_filepath (str): Path to the output JSON file (default: "clasp-list.json").
+    """
+    projects = []
+    try:
+        with open(input_filepath, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        print(f"Error: Input file '{input_filepath}' not found.")
+        return
+    except IOError as e:
+        print(f"Error reading file '{input_filepath}': {e}")
+        return
+
+    if not lines:
+        print(f"Warning: Input file '{input_filepath}' is empty.")
+        return
+
+    # Regex to capture script name (handling potential "..." and whitespace)
+    # and script ID from the URL.
+    # Example line: Script Name (...) - https://script.google.com/d/SCRIPT_ID_FOOBAR/edit
+    # Another example: Another Script Name - https://script.google.com/d/SCRIPT_ID_BAZQUX/edit
+    project_line_regex = re.compile(r"^(.*?)(?:\s*\(\.\.\.\))?\s+-\s+https://script\.google\.com/d/([^/]+)/edit.*$")
+
+    for line in lines[1:]:  # Skip the first line "Found X scripts."
+        line = line.strip()
+        if not line:
+            continue
+
+        match = project_line_regex.match(line)
+        if match:
+            script_name = match.group(1).strip()
+            script_id = match.group(2).strip()
+            projects.append({"name": script_name, "id": script_id})
+        else:
+            print(f"Warning: Could not parse line: '{line}'")
+
+    try:
+        with open(output_filepath, 'w', encoding='utf-8') as f:
+            json.dump(projects, f, indent=4, ensure_ascii=False)
+        print(f"Successfully parsed {len(projects)} projects and saved to '{output_filepath}'")
+    except IOError as e:
+        print(f"Error writing JSON to file '{output_filepath}': {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred during JSON writing: {e}")
+
+
+if __name__ == "__main__":
+    parse_clasp_list()
+    # Example of how to use it with different file names:
+    # parse_clasp_list(input_filepath="my_scripts.txt", output_filepath="my_scripts.json")


### PR DESCRIPTION
Here's a summary of the changes:

- I added a Python script named `parse_clasp_list.py` to the repository root. This script will process `clasp-list.txt`, extract the script name and ID, and create `clasp-list.json`.
- I modified the GitHub workflow located at `.github/workflows/update-clasp-list.yml`:
    - I added a new step to run `parse_clasp_list.py` after `clasp-list.txt` has been updated.
    - The workflow will now commit both `clasp-list.txt` and the newly generated `clasp-list.json` if any changes are detected in `clasp-list.txt`.

This will ensure you have a machine-readable JSON format of the Apps Script projects list in addition to the existing text file.